### PR TITLE
feat(SIGEBI): SIGEBI-Catálogos- Delegaciones. 5.- Nombres de campos erroneos

### DIFF
--- a/src/app/pages/catalogs/delegations/delegation-form/delegation-form.component.html
+++ b/src/app/pages/catalogs/delegations/delegation-form/delegation-form.component.html
@@ -170,7 +170,7 @@
         <div class="col-md-3">
           <form-field
             [control]="delegationForm.get('noRegister')"
-            label="noRegistro">
+            label="No. Registro">
             <input
               type="number"
               class="form-control"

--- a/src/app/pages/catalogs/delegations/delegation-list/delegation-columns.ts
+++ b/src/app/pages/catalogs/delegations/delegation-list/delegation-columns.ts
@@ -5,7 +5,7 @@ export const DELEGATION_COLUMS = {
     sort: false,
   },
   description: {
-    title: 'Desc',
+    title: 'Descripción',
     type: 'string',
     sort: false,
   },


### PR DESCRIPTION
En la ventana de nuevo y modificar el campo noRegistro el nombre debe ser "No. Registro". Igual el mismo registro en la columna, en las columnas cambiar Desc por "Descripción"

http://sigebidev.indep.gob.mx/pages/catalogs/delegations